### PR TITLE
add missing developer info (OSSRH requirement)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,15 @@
         <url>https://www.absa.africa</url>
     </organization>
 
+    <developers>
+        <developer>
+            <id>AbsaOSS/absaoss</id>
+            <name>ABSA R&amp;D team</name>
+            <timezone>Europe/Prague</timezone>
+            <url>https://github.com/orgs/AbsaOSS/teams/absaoss</url>
+        </developer>
+    </developers>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
 
     <packaging>pom</packaging>
 
+    <name>root-pom</name>
+    <description>ABSA OSS Root POM</description>
+
     <url>https://absaoss.github.io/</url>
 
     <scm>


### PR DESCRIPTION
Last time I was too aggressive cleaning stuff up, and removed developer info and project description tags which are actually required by OSSRH

```
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) on project root-pom: Remote staging failed: Staging rules failure! -> [Help 1]
  org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:deploy (injected-nexus-deploy) on project root-pom: Remote staging failed: Staging rules failure!
```