### PR TITLE
#4 - Add code coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Simply activate `license-check` profile on any Maven phase.
 mvn validate -Dlicense-check
 ```  
 
+### Measure code coverage
+
+Simply activate `code-coverage` profile on verify Maven phase.
+
+```shell
+mvn verify -Dcode-coverage
+```  
+
 See [Maven RAT plugin](https://creadur.apache.org/rat/apache-rat-plugin/index.html)
 
 ### Deploy to OSSRH (Maven Central)

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,9 @@
 
         <!-- The optional prefix for the base images in Dockerfile (mainly used in custom CI/CD pipelines to pull images from alternative locations) -->
         <dockerfile.baseImagePrefix><!-- defined externally --></dockerfile.baseImagePrefix>
+
+        <!-- Test -->
+        <jacoco.version>0.8.8</jacoco.version>
     </properties>
 
     <profiles>
@@ -308,6 +311,39 @@
                             </buildArgs>
                             <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- Enables JaCoCo code coverage measuring -->
+        <profile>
+            <id>code-coverage</id>
+            <activation>
+                <property>
+                    <name>code-coverage</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>jacoco-report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
- Added new profile for code coverage.
- Extended `readme.md` file for how to hint.

Closes #4 