### PR TITLE
10 - Fix argLine overloading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,7 @@
 
         <!-- Test -->
         <jacoco.version>0.8.10</jacoco.version>
-        <!-- Empty initialization required to protect JaCoCo agent settings from parent-pom (in code-coverage profile). -->
-        <argLine />
+        <default.scalatest.argLine/>
     </properties>
 
     <profiles>
@@ -327,6 +326,9 @@
                     <name>code-coverage</name>
                 </property>
             </activation>
+            <properties>
+                <scalatest.argLine>${default.scalatest.argLine} ${argLine}</scalatest.argLine>
+            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
- Previous solution refactored to generate all expected jacoco report outputs and do not damage ‘mvn install‘.

Closes #10 