### PR TITLE
Feature/root pom 15 multi arch builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ In the corresponding `pom.xml`, specify the Docker image name and enable the doc
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <properties>
-        <dockerfile.imageName>my-docker-image</dockerfile.imageName>
+        <docker.imageName>my-docker-image</docker.imageName>
     </properties>
 
     <build>
@@ -184,26 +184,26 @@ In the corresponding `pom.xml`, specify the Docker image name and enable the doc
 ```
 
 To build the Docker image execute Maven `install` phase with the `docker` profile enabled. You also need to specify the
-mandatory `dockerfile.repositoryUrl`. It serves as the image name prefix, and is mandatory even if you don't want to push the image in any remote
+mandatory `docker.repositoryUrl`. It serves as the image name prefix, and is mandatory even if you don't want to push the image in any remote
 repo.
 
 ```shell
-mvn install -Ddocker -Ddockerfile.repositoryUrl=foo
+mvn install -Ddocker -Ddocker.repositoryUrl=foo
 ```
 
 The above example will create a Docker image with the name `foo/my-docker-image` and two tags - `latest` and `x.y.z` (corresponding the POM version)
 
 ##### Push the image to a remote repository
-Specify `dockerfile.repositoryUrl` property accordingly and execute Maven `deploy` phase.
+Specify `docker.repositoryUrl` property accordingly and execute Maven `deploy` phase.
 
 The example command below with create an image and push into the AbsaOSS space on the Docker Hub.
 ```shell
-mvn deploy -Ddocker -Ddockerfile.repositoryUrl=docker.io/absaoss
+mvn deploy -Ddocker -Ddocker.repositoryUrl=docker.io/absaoss
 ```
 
 ##### Tweaking image names and tags
 
-See the `<dockerfile.*>` properties in the root `pom.xml` for details. All those parameters can be set/overwritten in the command line.
+See the `<docker.*>` properties in the root `pom.xml` for details. All those parameters can be set/overwritten in the command line.
 
 ```shell
 mvn ... -Dxxx.yyy=zzz

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,8 @@
         <docker.repositorySuffix><!-- defined externally --></docker.repositorySuffix>
         <docker.repository>${dockerfile.repositoryPrefix}${dockerfile.imageName}${dockerfile.repositorySuffix}</docker.repository>
 
+        <docker.platforms><!-- defined externally --></docker.platforms>
+
         <!--
             The properties with the prefix `dockerfile.*` are deprecated, and stay here for backward compatibility only.
             Outside of this POM, use their shorter variant `docker.*` instead.
@@ -318,6 +320,11 @@
                                             <tag>${dockerfile.latestTagName}</tag>
                                         </tags>
                                         <filter>false</filter>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>${docker.platforms}</platform>
+                                            </platforms>
+                                        </buildx>
                                         <args>
                                             <PROJECT_NAME>${project.name}</PROJECT_NAME>
                                             <PROJECT_GROUP_ID>${project.groupId}</PROJECT_GROUP_ID>
@@ -435,7 +442,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.40.3</version>
+                    <version>0.43.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -70,26 +70,44 @@
         <!-- Docker -->
 
         <!-- [REQUIRED] Must be defined in submodules -->
-        <dockerfile.imageName><!-- defined in submodules --></dockerfile.imageName>
+        <docker.imageName><!-- defined in submodules --></docker.imageName>
 
-        <dockerfile.versionTagPrefix><!-- defined externally --></dockerfile.versionTagPrefix>
-        <dockerfile.versionTagSuffix><!-- defined externally --></dockerfile.versionTagSuffix>
-        <dockerfile.versionTagName>${dockerfile.versionTagPrefix}${project.version}${dockerfile.versionTagSuffix}</dockerfile.versionTagName>
+        <docker.versionTagPrefix><!-- defined externally --></docker.versionTagPrefix>
+        <docker.versionTagSuffix><!-- defined externally --></docker.versionTagSuffix>
+        <docker.versionTagName>${dockerfile.versionTagPrefix}${project.version}${dockerfile.versionTagSuffix}</docker.versionTagName>
 
-        <dockerfile.latestTagPrefix><!-- defined externally --></dockerfile.latestTagPrefix>
-        <dockerfile.latestTagSuffix><!-- defined externally --></dockerfile.latestTagSuffix>
-        <dockerfile.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</dockerfile.latestTagName>
+        <docker.latestTagPrefix><!-- defined externally --></docker.latestTagPrefix>
+        <docker.latestTagSuffix><!-- defined externally --></docker.latestTagSuffix>
+        <docker.latestTagName>${dockerfile.latestTagPrefix}latest${dockerfile.latestTagSuffix}</docker.latestTagName>
 
         <!--
-            One of `dockerfile.repositoryUrl`, `dockerfile.repositoryPrefix` or `dockerfile.repository`
+            One of `docker.repositoryUrl`, `docker.repositoryPrefix` or `docker.repository`
             properties is required to be explicitly provided in the `mvn` command,
-            so that the resulted `dockerfile.repository` property has a correct value.
+            so that the resulted `docker.repository` property has a correct value.
         -->
 
-        <dockerfile.repositoryUrl><!-- defined externally --></dockerfile.repositoryUrl>
-        <dockerfile.repositoryPrefix>${dockerfile.repositoryUrl}/</dockerfile.repositoryPrefix>
-        <dockerfile.repositorySuffix><!-- defined externally --></dockerfile.repositorySuffix>
-        <dockerfile.repository>${dockerfile.repositoryPrefix}${dockerfile.imageName}${dockerfile.repositorySuffix}</dockerfile.repository>
+        <docker.repositoryUrl><!-- defined externally --></docker.repositoryUrl>
+        <docker.repositoryPrefix>${dockerfile.repositoryUrl}/</docker.repositoryPrefix>
+        <docker.repositorySuffix><!-- defined externally --></docker.repositorySuffix>
+        <docker.repository>${dockerfile.repositoryPrefix}${dockerfile.imageName}${dockerfile.repositorySuffix}</docker.repository>
+
+        <!--
+            The properties with the prefix `dockerfile.*` are deprecated, and stay here for backward compatibility only.
+            Outside of this POM, use their shorter variant `docker.*` instead.
+            Inside this POM, we should stick to `dockerfile.*` for now, to support both variants.
+        -->
+
+        <dockerfile.imageName>${docker.imageName}</dockerfile.imageName>
+        <dockerfile.versionTagPrefix>${docker.versionTagPrefix}</dockerfile.versionTagPrefix>
+        <dockerfile.versionTagSuffix>${docker.versionTagSuffix}</dockerfile.versionTagSuffix>
+        <dockerfile.versionTagName>${docker.versionTagName}</dockerfile.versionTagName>
+        <dockerfile.latestTagPrefix>${docker.latestTagPrefix}</dockerfile.latestTagPrefix>
+        <dockerfile.latestTagSuffix>${docker.latestTagSuffix}</dockerfile.latestTagSuffix>
+        <dockerfile.latestTagName>${docker.latestTagName}</dockerfile.latestTagName>
+        <dockerfile.repositoryUrl>${docker.repositoryUrl}</dockerfile.repositoryUrl>
+        <dockerfile.repositoryPrefix>${docker.repositoryPrefix}</dockerfile.repositoryPrefix>
+        <dockerfile.repositorySuffix>${docker.repositorySuffix}</dockerfile.repositorySuffix>
+        <dockerfile.repository>${docker.repository}</dockerfile.repository>
 
         <!-- Test -->
         <jacoco.version>0.8.10</jacoco.version>


### PR DESCRIPTION
Fixes #15 

- Introduce a new property `docker.platforms` that enable multi-platform builds. Change the `maven-docker-plugin` config accordingly.
- Add renamed aliases `docker.` for the existing properties `dockerfile.*`, and deprecate the later ones for brevity and consistency reasons. Backward compatibility with the existing client POMs is preserved.
- Add a forked copy of the docker plugin to fix an auth issue on `docker.io` (see fabric8io/docker-maven-plugin#1688). This change is likely temporary, until the PR is merged into the main repo reasonably quickly.